### PR TITLE
Feature/geoloc

### DIFF
--- a/Assets/js/modal.js
+++ b/Assets/js/modal.js
@@ -23,9 +23,16 @@ const zipLocEl = document.getElementById("zipLocEl");
 const zipInputEl = document.getElementById("zipInput");
 
 document.addEventListener('DOMContentLoaded', function() {
+  // fixes a limitation in jQuery UI dialog boxes wherein they do not recenter if the viewport size changes
   $(window).resize(function() {
     $("#locOptionsSet").dialog("option", "position", {my: "center", at: "center", of: window});
   });
+
+  // selects "Postal Code" radio button if user changes the zip code input box
+  zipInput.addEventListener("input", (function() {
+    zipLocEl.click() // I used this instead of changing the state to true because changing the state does not invoke the jQuery UI functions to visually activate the radio button
+  }));
+  
   const form = document.getElementById("myForm");
   if (form) {
     form.addEventListener("submit", (event) => {

--- a/Assets/js/modal.js
+++ b/Assets/js/modal.js
@@ -23,7 +23,9 @@ const zipLocEl = document.getElementById("zipLocEl");
 const zipInputEl = document.getElementById("zipInput");
 
 document.addEventListener('DOMContentLoaded', function() {
-
+  $(window).resize(function() {
+    $("#locOptionsSet").dialog("option", "position", {my: "center", at: "center", of: window});
+  });
   const form = document.getElementById("myForm");
   if (form) {
     form.addEventListener("submit", (event) => {

--- a/modal.html
+++ b/modal.html
@@ -25,18 +25,18 @@
         <div id = "locOptionsSet" title = "Location Method">
             <h2 id = "locOptionQuery" class = "exo-font">How Should I Find Your Map?</h2>
             <form id = "myForm">
-                <div id = "geoLoc">
-                    <label for = "geoLocEl" class = "exo-font">Geolocation
-                        <input name = "locatorOpt" type = "radio" id = "geoLocEl" checked>
-                    </label>
-                </div>
-                <div id = "zipLoc">
-                    <label for = "zipLocEl" class="exo-font">Postal Code
-                        <input name = "locatorOpt" type = "radio" id = "zipLocEl">
-                        <input id = "zipInput" placeholder = "Zip code" type = "number">
-                    </label>
-                </div>
-                <button type = "submit" id = "submitBtn">Go!</button>
+            <div id = "geoLoc">
+                <label for = "geoLocEl" class = "exo-font">Geolocation
+                    <input name = "locatorOpt" type = "radio" id = "geoLocEl" checked>
+                </label>
+            </div>
+            <div id = "zipLoc">
+                <label for = "zipLocEl" class="exo-font">Postal Code
+                    <input name = "locatorOpt" type = "radio" id = "zipLocEl">
+                    <input id = "zipInput" placeholder = "Zip code" type = "number">
+                </label>
+            </div>
+            <button type = "submit" id = "submitBtn">Go!</button>
             </form>
         </div>
         <script>

--- a/modal.html
+++ b/modal.html
@@ -15,7 +15,8 @@
             $(function() {
                 $("#locOptionsSet").dialog({
                     autoOpen: true,
-                    modal: true
+                    modal: true,
+                    closeOnEscape: false
                 });
             });
         </script>


### PR DESCRIPTION
fixed jQuery UI limitation wherein dialogs don't recenter if the viewport is resized
associated zip-code radio and zip-code input so that if user begins typing a zip code without first clicking on the zip-code radio button, the button is automatically "clicked" and becomes the chosen option